### PR TITLE
Reject fetch promise on error

### DIFF
--- a/src/assetsloader.js
+++ b/src/assetsloader.js
@@ -18,7 +18,7 @@ function fetchFile (fileURL, isRaw) {
       }
     }
 
-    request.onerror = (error) => createFetchError(fileURL, error)
+    request.onerror = (error) => reject(createFetchError(fileURL, error))
 
     request.send()
   })


### PR DESCRIPTION
Hi,

first of all thanks for your work, it helped me a lot reducing my bundle size in my project.

I've found a small issue in the error handling, the fetch promise is not rejected when an error happens and this blocks the execution.

With this small fix the promise will be rejected and the `load` function can handle the exception properly.